### PR TITLE
Update ros2_control

### DIFF
--- a/prbt_robot_moveit_config/config/moveit_controllers.yaml
+++ b/prbt_robot_moveit_config/config/moveit_controllers.yaml
@@ -11,48 +11,6 @@ moveit_controller_manager: moveit_simple_controller_manager/MoveItSimpleControll
 moveit_simple_controller_manager:
   controller_names:
     - arm_controller
-    - prbt_joint_1_controller
-    - prbt_joint_2_controller
-    - prbt_joint_3_controller
-    - prbt_joint_4_controller
-    - prbt_joint_5_controller
-    - prbt_joint_6_controller
-
-  # prbt_joint_1_controller:
-  #   action_ns: switch_on
-  #   type: canopen_ros2_controllers/Cia402DeviceController
-  #   joints: 
-  #     - prbt_joint_1
-
-  # prbt_joint_2_controller:
-  #   action_ns: switch_on
-  #   type: canopen_ros2_controllers/Cia402DeviceController
-  #   joints: 
-  #     - prbt_joint_2
-
-  # prbt_joint_3_controller:
-  #   action_ns: switch_on
-  #   type: canopen_ros2_controllers/Cia402DeviceController
-  #   joints: 
-  #     - prbt_joint_3
-
-  # prbt_joint_4_controller:
-  #   action_ns: switch_on
-  #   type: canopen_ros2_controllers/Cia402DeviceController
-  #   joints: 
-  #     - prbt_joint_4
-
-  # prbt_joint_5_controller:
-  #   action_ns: switch_on
-  #   type: canopen_ros2_controllers/Cia402DeviceController
-  #   joints: 
-  #     - prbt_joint_5
-
-  # prbt_joint_6_controller:
-  #   action_ns: switch_on
-  #   type: canopen_ros2_controllers/Cia402DeviceController
-  #   joints: 
-  #     - prbt_joint_6
 
   arm_controller:
     type: FollowJointTrajectory
@@ -65,7 +23,3 @@ moveit_simple_controller_manager:
       - prbt_joint_4
       - prbt_joint_5
       - prbt_joint_6
-      
-# initial:  # Define initial robot poses per group
-#   - group: arm
-#     pose: Home

--- a/prbt_robot_moveit_config/package.xml
+++ b/prbt_robot_moveit_config/package.xml
@@ -32,7 +32,7 @@
   <exec_depend>moveit_configs_utils</exec_depend>
   <exec_depend>moveit_ros_move_group</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>
-  <exec_depend>moveit_ros_warehouse</exec_depend>
+  <!-- <exec_depend>moveit_ros_warehouse</exec_depend> -->
   <exec_depend>moveit_setup_assistant</exec_depend>
   <exec_depend>prbt_robot_support</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
@@ -40,7 +40,7 @@
   <exec_depend>rviz_common</exec_depend>
   <exec_depend>rviz_default_plugins</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
-  <exec_depend>warehouse_ros_mongo</exec_depend>
+  <!-- <exec_depend>warehouse_ros_mongo</exec_depend> -->
   <exec_depend>xacro</exec_depend>
 
 

--- a/prbt_robot_support/urdf/prbt.ros2_control.xacro
+++ b/prbt_robot_support/urdf/prbt.ros2_control.xacro
@@ -3,8 +3,9 @@
 
     <xacro:arg name="bus_config" default="$(find prbt_robot_support)/config/prbt/bus.yml"/>
     <xacro:arg name="master_config" default="$(find prbt_robot_support)/config/prbt/master.dcf"/>
-    <xacro:arg name="can_interface_name" default="vcan0"/>
+    <xacro:arg name="can_interface_name" default="can0"/>
     <xacro:arg name="master_bin" default=""/>
+    <xacro:arg name="robot_prefix" default=""/>
 
     <xacro:macro name="prbt_ros2_control" params="
       name

--- a/prbt_robot_support/urdf/prbt.ros2_control.xacro
+++ b/prbt_robot_support/urdf/prbt.ros2_control.xacro
@@ -1,6 +1,11 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
+    <xacro:arg name="bus_config" default="$(find prbt_robot_support)/config/prbt/bus.yml"/>
+    <xacro:arg name="master_config" default="$(find prbt_robot_support)/config/prbt/master.dcf"/>
+    <xacro:arg name="can_interface_name" default="vcan0"/>
+    <xacro:arg name="master_bin" default=""/>
+
     <xacro:macro name="prbt_ros2_control" params="
       name
       prefix
@@ -39,4 +44,12 @@
 
     </xacro:macro>
 
+    <xacro:prbt_ros2_control
+        name="$(arg robot_prefix)"
+        prefix="$(arg robot_prefix)"
+        bus_config="$(arg bus_config)"
+        master_config="$(arg master_config)"
+        can_interface_name="$(arg can_interface_name)"
+        master_bin="$(arg master_bin)" />
+        
 </robot>


### PR DESCRIPTION
This PR:
- Update ros2_control.xacro
- Removed unused controllers list from simple moveit config file
- Removed warehouse mango dependency to fix rosdep install error.

